### PR TITLE
Valet Admin Garage Parking Spots Controllers

### DIFF
--- a/account_controllers/controllers.js
+++ b/account_controllers/controllers.js
@@ -336,20 +336,9 @@ module.exports = {
         const { id } = req.params;
         const { spots } = req.body;
 
-        const { error: garageError } = await supabase
-          .from('garages')
-          .update({ spots })
-          .eq('user_id', id)
-          .single();
-
-        if (garageError) {
-          console.error('Error updating garage parking spots:', garageError);
-          return res.sendStatus(500);
-        }
-
         const { data: garageData, error: garageDataError } = await supabase
           .from('garages')
-          .select('id')
+          .select('id, spots')
           .eq('user_id', id)
           .single();
 
@@ -359,6 +348,32 @@ module.exports = {
         }
 
         const garageId = garageData.id;
+        const formattedNext7Days = [...Array(7)].map((_, index) =>
+          DateTime.local()
+            .startOf('day')
+            .plus({ days: index })
+            .toFormat('MM-dd-yy')
+        );
+
+        const { data: conflictingReservations, error: reservationError } =
+          await supabase
+            .from('reservations')
+            .select('parking_spot_id')
+            .eq('garage_id', garageId)
+            .in('status', ['reserved', 'checked-in'])
+            .in('date', formattedNext7Days);
+
+        if (reservationError) {
+          console.error(
+            'Error retrieving conflicting reservations:',
+            reservationError
+          );
+          return res.sendStatus(500);
+        }
+
+        const conflictingSpotIds = conflictingReservations.map(
+          (reservation) => reservation.parking_spot_id
+        );
 
         const { data: existingSpots, error: existingSpotsError } =
           await supabase
@@ -375,48 +390,70 @@ module.exports = {
         }
 
         const existingSpotIds = existingSpots.map((spot) => spot.id);
-
+        const availableSpotIds = existingSpotIds.filter(
+          (spotId) => !conflictingSpotIds.includes(spotId)
+        );
         const numSpotsToAdd = spots - existingSpotIds.length;
 
         if (numSpotsToAdd > 0) {
           const newSpotIds = await Promise.all(
             Array.from({ length: numSpotsToAdd }, async () => {
-              const { error: newSpotError } = await supabase
-                .from('parking_spots')
-                .insert({
-                  garage_id: garageId,
-                })
-                .single();
+              try {
+                const { data: newSpotData, error: newSpotError } =
+                  await supabase
+                    .from('parking_spots')
+                    .insert({
+                      garage_id: garageId,
+                    })
+                    .select();
 
-              if (newSpotError) {
-                console.error('Error adding new parking spot:', newSpotError);
+                if (newSpotError) {
+                  console.error('Error adding new parking spot:', newSpotError);
+                  return null;
+                }
+
+                if (!newSpotData) {
+                  console.error(
+                    'Unexpected response from Supabase:',
+                    newSpotData
+                  );
+                  return null;
+                }
+
+                return newSpotData.id;
+              } catch (insertError) {
+                console.error('Error during insertion:', insertError);
                 return null;
               }
             })
           );
 
           const filteredNewSpotIds = newSpotIds.filter(
-            (spotsId) => spotsId !== null
+            (filteredid) => filteredid !== null
           );
-          const allSpotIds = existingSpotIds.concat(filteredNewSpotIds);
+          const allSpotIds = availableSpotIds.concat(filteredNewSpotIds);
+
+          await supabase.from('garages').update({ spots }).eq('id', garageId);
 
           res.status(200).json({ garageId, spotIds: allSpotIds });
         } else if (numSpotsToAdd < 0) {
-          const spotsToRemove = existingSpotIds.slice(0, -numSpotsToAdd);
+          const spotsToRemove = availableSpotIds.slice(numSpotsToAdd);
 
-          const { error: removeSpotsError } = await supabase
-            .from('parking_spots')
-            .delete()
-            .in('id', spotsToRemove);
-
-          if (removeSpotsError) {
-            console.error('Error removing parking spots:', removeSpotsError);
-            return res.sendStatus(500);
+          if (availableSpotIds.length < Math.abs(numSpotsToAdd)) {
+            return res.status(400).json({
+              error: 'Cannot remove spots due to conflicting reservations.',
+            });
           }
+
+          await supabase.from('parking_spots').delete().in('id', spotsToRemove);
+
+          await supabase.from('garages').update({ spots }).eq('id', garageId);
 
           res.status(200).json({ garageId, removedSpotIds: spotsToRemove });
         } else {
-          res.status(200).json({ garageId, spotIds: existingSpotIds });
+          await supabase.from('garages').update({ spots }).eq('id', garageId);
+
+          res.status(200).json({ garageId, spotIds: availableSpotIds });
         }
       } catch (error) {
         console.error('Error updating garage parking spots:', error);

--- a/account_controllers/controllers.js
+++ b/account_controllers/controllers.js
@@ -451,9 +451,11 @@ module.exports = {
 
           res.status(200).json({ garageId, removedSpotIds: spotsToRemove });
         } else {
-          await supabase.from('garages').update({ spots }).eq('id', garageId);
-
-          res.status(200).json({ garageId, spotIds: availableSpotIds });
+          res.status(200).json({
+            message:
+              'No changes needed. Requested spots are the same as current spots.',
+            garageId,
+          });
         }
       } catch (error) {
         console.error('Error updating garage parking spots:', error);


### PR DESCRIPTION
### editGarageParkingSpots Controller

1. Fetch the user_id and spots from client side
2. Check for conflicting reservations by conditions:

  - within 7 dates from today
  - status = 'reserved' or  'checked-in'
  - garage_id equals the garage_id that the valet owns

3. Find the conflicting parking_spots_id from reservations (these would be the spots that we cannot remove due to current reservation)
4. Query for parking_spots table and find the available spots, which is a subset of existing spots and conflicting spots
5. Calculate number of spots to add (+, -, 0)
6. If numSpotsToAdd > 0,  then we will add spots
7. If numSpotsToAdd< 0, then we will remove spots based on available spots. However, if the available spots is less than the number of spots to add, then flag the admin that they cannot remove spots due to conflicting reservations.
8. If spots requested are the same, everything remains the same and nothing is removed nor added.

Results:

**Spots Removed**
![SpotsRemoved](https://github.com/pokemon-parKing/parKing-account-server/assets/144174704/27b4b76c-845a-4dcd-9528-2ac42030e998)

**Spots Added**
![SpotsAdded](https://github.com/pokemon-parKing/parKing-account-server/assets/144174704/89b8bbd3-10b3-4534-b382-7ea52441d8b2)

**Spots Same**
![SpotsSame](https://github.com/pokemon-parKing/parKing-account-server/assets/144174704/d00eefda-6513-4643-86eb-7b74f7fbad01)

**Cannot Remove Due to Conflicting Reservation**
![CannotRemoveSpots](https://github.com/pokemon-parKing/parKing-account-server/assets/144174704/12e798f6-8dd2-4488-b908-3640c3138326)
![CannotRemoveSpots2](https://github.com/pokemon-parKing/parKing-account-server/assets/144174704/439c75de-6e66-4637-b479-28a58d645711)

### TLDR
### This is a pretty complicated controller with substantial amount of checks to ensure no spots will be deleted that are currently in checked in or reservation.
